### PR TITLE
Further updates for Drupal 9 compatibility

### DIFF
--- a/src/ContextProvider/TaxonomyTermContext.php
+++ b/src/ContextProvider/TaxonomyTermContext.php
@@ -4,7 +4,6 @@ namespace Drupal\custom_context_provider\ContextProvider;
 
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Plugin\Context\Context;
-use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Context\EntityContextDefinition;
 use Drupal\Core\Plugin\Context\ContextProviderInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
@@ -42,7 +41,7 @@ class TaxonomyTermContext implements ContextProviderInterface
     public function getRuntimeContexts(array $unqualified_context_ids)
     {
         $result = [];
-        $context_definition = new ContextDefinition('entity:taxonomy_term', $this->t('Taxonomy term from URL'));
+        $context_definition = new EntityContextDefinition('entity:taxonomy_term', $this->t('Taxonomy term from URL'));
         $value = null;
         if (($route_object = $this->routeMatch->getRouteObject())
             && ($route_contexts = $route_object->getOption('parameters'))


### PR DESCRIPTION
These changes are required for compatibility with Drupal 9. The previous commit changed `ContextDefinition` to EntityContextDefinition` in one place but not the other. Without this change, an Assertion Error is thrown when updating a Drupal 8 `site to Drupal 9. For more details, read about my experience at [https://www.drupal.org/project/drupal/issues/3210519](https://www.drupal.org/project/drupal/issues/3210519). Further discussion may ensue on [https://www.drupal.org/project/ctools/issues/2712679](https://www.drupal.org/project/ctools/issues/2712679), where I will also report this.